### PR TITLE
Fix tm and hm compatibility by making all entries 16 bytes long

### DIFF
--- a/include/tutors.h
+++ b/include/tutors.h
@@ -68,15 +68,15 @@ enum MoveTutors
 	TUTOR63_PSYCHIC_TERRAIN,
 
 //Special Move Tutors - Not in Table
-	TUTOR_SPECIAL_DRACO_METEOR,			//128 - Dragon Pokemon
-	TUTOR_SPECIAL_SECRET_SWORD,			//129 - Keldeo only
-	TUTOR_SPECIAL_RELIC_SONG,			//130 - Meloetta only
-	TUTOR_SPECIAL_VOLT_TACKLE,			//131 - Pikachu only
-	TUTOR_SPECIAL_DRAGON_ASCENT,		//132 - Rayquaza only
-	TUTOR_SPECIAL_THOUSAND_ARROWS,		//133 - Zygarde only
-	TUTOR_SPECIAL_THOUSAND_WAVES,		//134 - Zygarde only
-	TUTOR_SPECIAL_CORE_ENFORCER,		//135 - Zygarde only
-	TUTOR_SPECIAL_STEEL_BEAM,			//136 - Steel Pokemon
+	TUTOR_SPECIAL_DRACO_METEOR,			//64 - Dragon Pokemon
+	TUTOR_SPECIAL_SECRET_SWORD,			//65 - Keldeo only
+	TUTOR_SPECIAL_RELIC_SONG,			//66 - Meloetta only
+	TUTOR_SPECIAL_VOLT_TACKLE,			//67 - Pikachu only
+	TUTOR_SPECIAL_DRAGON_ASCENT,		//68 - Rayquaza only
+	TUTOR_SPECIAL_THOUSAND_ARROWS,		//69 - Zygarde only
+	TUTOR_SPECIAL_THOUSAND_WAVES,		//70 - Zygarde only
+	TUTOR_SPECIAL_CORE_ENFORCER,		//71- Zygarde only
+	TUTOR_SPECIAL_STEEL_BEAM,			//72 - Steel Pokemon
 };
 
-#define LAST_TOTAL_TUTOR_NUM 136
+#define LAST_TOTAL_TUTOR_NUM 72

--- a/scripts/tm_tutor.py
+++ b/scripts/tm_tutor.py
@@ -3,7 +3,7 @@ import sys
 from glob import glob
 
 # Data
-TM_HM_COUNT = 106
+TM_HM_COUNT = 128
 TUTOR_COUNT = 64
 SPECIES_COUNT = 0x4F3 + 1
 


### PR DESCRIPTION
Fix TM/HM Compatibility by making all entries written as 16 bytes long, instead of however much they need (previously 13). This allows movesets to remain correct.